### PR TITLE
Giftcard 2.0 email

### DIFF
--- a/app/controllers/spree/admin/gift_cards_controller.rb
+++ b/app/controllers/spree/admin/gift_cards_controller.rb
@@ -72,7 +72,7 @@ class Spree::Admin::GiftCardsController < Spree::Admin::BaseController
   end
 
   def gift_card_params
-    params.require(:virtual_gift_card).permit(:recipient_name, :recipient_email, :purchaser_name, :gift_message)
+    params.require(:virtual_gift_card).permit(:recipient_name, :recipient_email, :purchaser_name, :gift_message, :send_email_at)
   end
 
   def model_class

--- a/app/models/concerns/spree/gift_cards/order_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_concerns.rb
@@ -29,8 +29,7 @@ module Spree
       def send_gift_card_emails
         gift_cards.each do |gift_card|
           if gift_card.send_email_at.nil? || gift_card.send_email_at <= DateTime.now
-            Spree::GiftCardMailer.gift_card_email(gift_card).deliver
-            gift_card.touch(:sent_at)
+            gift_card.send_email
           end
         end
       end

--- a/app/models/concerns/spree/gift_cards/order_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_concerns.rb
@@ -14,8 +14,9 @@ module Spree
       def gift_card_match(line_item, options)
         return true unless line_item.gift_card?
         line_item.gift_cards.any? do |gift_card|
-          gift_card_detail_set = gift_card.details.stringify_keys.to_set
-          gift_card_detail_set.superset?(options["gift_card_details"].to_set)
+          gc_detail_set = gift_card.details.stringify_keys.except("send_email_at").to_set
+          options_set = options["gift_card_details"].except("send_email_at").to_set
+          gc_detail_set.superset?(options_set)
         end
       end
 

--- a/app/models/concerns/spree/gift_cards/order_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_concerns.rb
@@ -28,7 +28,10 @@ module Spree
 
       def send_gift_card_emails
         gift_cards.each do |gift_card|
-          Spree::GiftCardMailer.gift_card_email(gift_card).deliver
+          if gift_card.send_email_at.nil? || gift_card.send_email_at <= DateTime.now
+            Spree::GiftCardMailer.gift_card_email(gift_card).deliver
+            gift_card.touch(:sent_at)
+          end
         end
       end
     end

--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -44,6 +44,7 @@ module Spree
               recipient_email: gift_card_details["recipient_email"],
               purchaser_name: gift_card_details["purchaser_name"],
               gift_message: gift_card_details["gift_message"],
+              send_email_at: gift_card_details["send_email_at"] || DateTime.now,
             )
           end
         end

--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -44,7 +44,7 @@ module Spree
               recipient_email: gift_card_details["recipient_email"],
               purchaser_name: gift_card_details["purchaser_name"],
               gift_message: gift_card_details["gift_message"],
-              send_email_at: gift_card_details["send_email_at"] || DateTime.now,
+              send_email_at: format_date(gift_card_details["send_email_at"])
             )
           end
         end
@@ -64,6 +64,18 @@ module Spree
           elsif new_quantity < line_item.gift_cards.count
             remove_gift_cards(line_item, gift_card_count - new_quantity)
           end
+        end
+      end
+
+      def format_date(date)
+        return date if date.acts_like? :time
+
+        # parse the date if its parse-able
+        # otherwise use the current date.
+        begin
+          DateTime.parse(date)
+        rescue
+          DateTime.now
         end
       end
     end

--- a/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
+++ b/app/models/concerns/spree/gift_cards/order_contents_concerns.rb
@@ -1,6 +1,7 @@
 module Spree
   module GiftCards::OrderContentsConcerns
     extend ActiveSupport::Concern
+    class GiftCardDateFormatError < StandardError; end
 
     included do
       prepend(InstanceMethods)
@@ -68,14 +69,13 @@ module Spree
       end
 
       def format_date(date)
-        return date if date.acts_like? :time
+        return date if date.acts_like?(:date) || date.acts_like?(:time)
+        return Date.today if date.nil?
 
-        # parse the date if its parse-able
-        # otherwise use the current date.
         begin
-          DateTime.parse(date)
-        rescue
-          DateTime.now
+          Date.parse(date)
+        rescue ArgumentError
+          raise GiftCardDateFormatError
         end
       end
     end

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -47,6 +47,7 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
       recipient_name: recipient_name,
       purchaser_name: purchaser_name,
       gift_message: gift_message,
+      send_email_at: send_email_at
     }
   end
 

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -67,6 +67,11 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
     Spree::VirtualGiftCard.unredeemed.by_redemption_code(redemption_code).first
   end
 
+  def send_email
+    Spree::GiftCardMailer.gift_card_email(self).deliver_later
+    touch(:sent_at)
+  end
+
   private
 
   def generate_unique_redemption_code

--- a/app/models/spree/virtual_gift_card.rb
+++ b/app/models/spree/virtual_gift_card.rb
@@ -9,7 +9,7 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
   validates :amount, numericality: { greater_than: 0 }
   validates_uniqueness_of :redemption_code, conditions: -> { where(redeemed_at: nil, redeemable: true) }
   validates_presence_of :purchaser_id, if: Proc.new { |gc| gc.redeemable? }
-  
+
   scope :unredeemed, -> { where(redeemed_at: nil) }
   scope :by_redemption_code, -> (redemption_code) { where(redemption_code: redemption_code) }
 
@@ -47,7 +47,8 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
       recipient_name: recipient_name,
       purchaser_name: purchaser_name,
       gift_message: gift_message,
-      send_email_at: send_email_at
+      send_email_at: send_email_at,
+      formatted_send_email_at: formatted_send_email_at
     }
   end
 
@@ -57,6 +58,10 @@ class Spree::VirtualGiftCard < ActiveRecord::Base
 
   def formatted_amount
     number_to_currency(amount, precision: 0)
+  end
+
+  def formatted_send_email_at
+    send_email_at.strftime("%-m/%-d/%y") if send_email_at
   end
 
   def store_credit_category

--- a/config/initializers/line_item_controller_gift_card_details.rb
+++ b/config/initializers/line_item_controller_gift_card_details.rb
@@ -1,4 +1,4 @@
 Rails.application.config.to_prepare do
-  Spree::Api::LineItemsController.line_item_options += [gift_card_details: [:recipient_name, :recipient_email, :gift_message, :purchaser_name]]
+  Spree::Api::LineItemsController.line_item_options += [gift_card_details: [:recipient_name, :recipient_email, :gift_message, :purchaser_name, :send_email_at]]
   Spree::Order.line_item_comparison_hooks.add('gift_card_match')
 end

--- a/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
+++ b/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
@@ -1,0 +1,7 @@
+class AddEmailSendTimeToVirtualGiftCard < ActiveRecord::Migration
+  def change
+    add_column :spree_virtual_gift_cards, :send_email_at, :datetime
+    add_column :spree_virtual_gift_cards, :sent_at, :datetime
+    add_index :spree_virtual_gift_cards, :send_email_at
+  end
+end

--- a/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
+++ b/db/migrate/20151019190731_add_email_send_time_to_virtual_gift_card.rb
@@ -1,6 +1,6 @@
 class AddEmailSendTimeToVirtualGiftCard < ActiveRecord::Migration
   def change
-    add_column :spree_virtual_gift_cards, :send_email_at, :datetime
+    add_column :spree_virtual_gift_cards, :send_email_at, :date
     add_column :spree_virtual_gift_cards, :sent_at, :datetime
     add_index :spree_virtual_gift_cards, :send_email_at
   end

--- a/lib/tasks/send_gift_card_emails.rake
+++ b/lib/tasks/send_gift_card_emails.rake
@@ -1,9 +1,8 @@
 namespace :solidus_virtual_gift_card do
   desc "Send todays gift card emails"
   task :send_current_emails => :environment do
-    Spree::VirtualGiftCard.where(send_email_at: DateTime.now.beginning_of_day..DateTime.now.end_of_day, sent_at: nil).each do |gift_card|
-      Spree::GiftCardMailer.gift_card_email(gift_card).deliver
-      gift_card.touch(:sent_at)
+    Spree::VirtualGiftCard.where(send_email_at: Date.today, sent_at: nil).find_each do |gift_card|
+      gift_card.send_email
     end
   end
 end

--- a/lib/tasks/send_gift_card_emails.rake
+++ b/lib/tasks/send_gift_card_emails.rake
@@ -1,0 +1,9 @@
+namespace :solidus_virtual_gift_card do
+  desc "Send todays gift card emails"
+  task :send_current_emails => :environment do
+    Spree::VirtualGiftCard.where(send_email_at: DateTime.now.beginning_of_day..DateTime.now.end_of_day, sent_at: nil).each do |gift_card|
+      Spree::GiftCardMailer.gift_card_email(gift_card).deliver
+      gift_card.touch(:sent_at)
+    end
+  end
+end

--- a/spec/lib/tasks/send_gift_card_emails_spec.rb
+++ b/spec/lib/tasks/send_gift_card_emails_spec.rb
@@ -13,15 +13,15 @@ describe "solidus_virtual_gift_card:send_current_emails" do
 
   context "with gift card sent today" do
     it "sends emails to be sent today" do
-      gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: DateTime.now)
-      expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver: true))
+      gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today)
+      expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
       subject
     end
   end
 
   context "with gift card already sent today" do
     it "sends emails to be sent today" do
-      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: DateTime.now, sent_at: DateTime.now)
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: Date.today, sent_at: DateTime.now)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject
     end
@@ -29,7 +29,7 @@ describe "solidus_virtual_gift_card:send_current_emails" do
 
   context "with gift cards sent in the future" do
     it "does not sends emails" do
-      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 10.days.from_now)
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 10.days.from_now.to_date)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject
     end
@@ -37,7 +37,7 @@ describe "solidus_virtual_gift_card:send_current_emails" do
 
   context "with gift cards sent in the past" do
     it "does not sends emails" do
-      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 1.days.ago, sent_at: 1.days.ago)
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 1.days.ago, sent_at: 1.days.ago.to_date)
       expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
       subject
     end

--- a/spec/lib/tasks/send_gift_card_emails_spec.rb
+++ b/spec/lib/tasks/send_gift_card_emails_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe "solidus_virtual_gift_card:send_current_emails" do
+
+  let(:task) { Rake::Task['solidus_virtual_gift_card:send_current_emails'] }
+
+  before do
+    Rails.application.load_tasks
+    task.reenable
+  end
+
+  subject { task.invoke }
+
+  context "with gift card sent today" do
+    it "sends emails to be sent today" do
+      gift_card = Spree::VirtualGiftCard.create!(amount: 50, send_email_at: DateTime.now)
+      expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver: true))
+      subject
+    end
+  end
+
+  context "with gift card already sent today" do
+    it "sends emails to be sent today" do
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: DateTime.now, sent_at: DateTime.now)
+      expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
+      subject
+    end
+  end
+
+  context "with gift cards sent in the future" do
+    it "does not sends emails" do
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 10.days.from_now)
+      expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
+      subject
+    end
+  end
+
+  context "with gift cards sent in the past" do
+    it "does not sends emails" do
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: 1.days.ago, sent_at: 1.days.ago)
+      expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
+      subject
+    end
+  end
+
+  context "with gift cards not specified" do
+    it "does not sends emails" do
+      Spree::VirtualGiftCard.create!(amount: 50, send_email_at: nil)
+      expect(Spree::GiftCardMailer).to_not receive(:gift_card_email)
+      subject
+    end
+  end
+end

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -9,6 +9,7 @@ describe Spree::OrderContents do
   let(:recipient_email) { "ron@weasly.com" }
   let(:purchaser_name) { "Harry Potter" }
   let(:gift_message) { "Thought you could use some trousers, mate" }
+  let(:send_email_at) { 2.days.from_now }
   let(:options) do
     {
       "gift_card_details" => {
@@ -16,6 +17,7 @@ describe Spree::OrderContents do
         "recipient_email" => recipient_email,
         "purchaser_name" => purchaser_name,
         "gift_message" => gift_message,
+        "send_email_at" => send_email_at,
       }
     }
   end
@@ -43,6 +45,27 @@ describe Spree::OrderContents do
           expect(gift_card.recipient_email).to eq(recipient_email)
           expect(gift_card.purchaser_name).to eq(purchaser_name)
           expect(gift_card.gift_message).to eq(gift_message)
+          expect(gift_card.send_email_at).to eq(send_email_at)
+        end
+
+        context "#format_date" do
+          context "without send_email_at" do
+            let(:send_email_at) { nil }
+            it "sets to current date" do
+              subject
+              gift_card = Spree::VirtualGiftCard.last
+              expect(gift_card.send_email_at.to_date).to eq(DateTime.now.to_date)
+            end
+          end
+
+          context "with send_email_at as a string" do
+            let(:send_email_at) { "12/14/2020" }
+            it "formats to a datetime" do
+              subject
+              gift_card = Spree::VirtualGiftCard.last
+              expect(gift_card.send_email_at.to_date).to eq(DateTime.new(2020, 12, 14).to_date)
+            end
+          end
         end
       end
 

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -45,7 +45,7 @@ describe Spree::OrderContents do
           expect(gift_card.recipient_email).to eq(recipient_email)
           expect(gift_card.purchaser_name).to eq(purchaser_name)
           expect(gift_card.gift_message).to eq(gift_message)
-          expect(gift_card.send_email_at).to eq(send_email_at)
+          expect(gift_card.send_email_at).to eq(send_email_at.to_date)
         end
 
         context "#format_date" do
@@ -54,16 +54,14 @@ describe Spree::OrderContents do
             it "sets to current date" do
               subject
               gift_card = Spree::VirtualGiftCard.last
-              expect(gift_card.send_email_at.to_date).to eq(DateTime.now.to_date)
+              expect(gift_card.send_email_at).to eq(Date.today)
             end
           end
 
-          context "with send_email_at as a string" do
+          context "with invalid date" do
             let(:send_email_at) { "12/14/2020" }
-            it "formats to a datetime" do
-              subject
-              gift_card = Spree::VirtualGiftCard.last
-              expect(gift_card.send_email_at.to_date).to eq(DateTime.new(2020, 12, 14).to_date)
+            it "errors" do
+             expect{ subject }.to raise_error Spree::GiftCards::OrderContentsConcerns::GiftCardDateFormatError
             end
           end
         end

--- a/spec/models/spree/order_contents_spec.rb
+++ b/spec/models/spree/order_contents_spec.rb
@@ -98,6 +98,7 @@ describe Spree::OrderContents do
                 "recipient_email" => recipient_email2,
                 "purchaser_name" => purchaser_name2,
                 "gift_message" => gift_message,
+                "send_email_at" => send_email_at,
               }
             }
           end
@@ -175,6 +176,7 @@ describe Spree::OrderContents do
               "recipient_email" => recipient_email2,
               "purchaser_name" => purchaser_name2,
               "gift_message" => gift_message,
+              "send_email_at" => send_email_at,
             }
           }
         end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -28,8 +28,8 @@ describe Spree::Order do
       context "send_email_at is not set" do
         let(:send_email_at) { nil }
         it "should call GiftCardMailer#send" do
-          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver: true))
-          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver: true))
+          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
+          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver_later: true))
           subject
           expect(gift_card.reload.sent_at).to be_present
         end
@@ -38,8 +38,8 @@ describe Spree::Order do
       context "send_email_at is in the past" do
         let(:send_email_at) { 2.days.ago }
         it "should call GiftCardMailer#send" do
-          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver: true))
-          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver: true))
+          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card).and_return(double(deliver_later: true))
+          expect(Spree::GiftCardMailer).to receive(:gift_card_email).with(gift_card_2).and_return(double(deliver_later: true))
           subject
           expect(gift_card.reload.sent_at).to be_present
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 
 require 'rspec/rails'
+require 'rake'
 
 require 'database_cleaner'
 require 'ffaker'


### PR DESCRIPTION
* Add send_email_at and sent_at DateTime fields to Spree::VirtualGiftCard
* Send gift cards that haven’t specified a send at date or whose send at date is the same date as order completion
* Add Rake task to send today’s gift cards that haven’t been sent
* Add specs